### PR TITLE
updated a very little typo.

### DIFF
--- a/python_sandbox_starter/conditionals.py
+++ b/python_sandbox_starter/conditionals.py
@@ -11,7 +11,7 @@
 
 
 
-# Membership Operators (not, not in) - Membership operators are used to test if a sequence is presented in an object
+# Membership Operators (in, not in) - Membership operators are used to test if a sequence is presented in an object
 
 
 


### PR DESCRIPTION
The membership operators listed had 'not'  written in place of 'in'. It's not a very big deal but could be misleading for new learners.